### PR TITLE
Use "recommended" nuget

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ assembly_info:
   assembly_file_version: 1.7.0.{build}
   assembly_informational_version: 1.7.0.{build}
 before_build:
+- cmd: appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
 - cmd: nuget restore
 build:
   verbosity: minimal


### PR DESCRIPTION
Use have v4.0.0 installed on `Visual Studio 2017` image as it supposed to be right version for VS2017 but apparently it does not always works well.